### PR TITLE
temporary fix for syscall/js.finalizeRef not implemented error

### DIFF
--- a/targets/wasm_exec.js
+++ b/targets/wasm_exec.js
@@ -298,9 +298,16 @@
 
 					// func finalizeRef(v ref)
 					"syscall/js.finalizeRef": (v_ref) => {
-						// Note: TinyGo does not support finalizers so this should never be
-						// called.
-						console.error('syscall/js.finalizeRef not implemented');
+						// Note: TinyGo does not support finalizers so this is only called
+						// for one specific case, by js.go:jsString.
+						const id = mem().getUint32(unboxValue(v_ref), true);
+						this._goRefCounts[id]--;
+						if (this._goRefCounts[id] === 0) {
+							const v = this._values[id];
+							this._values[id] = null;
+							this._ids.delete(v);
+							this._idPool.push(id);
+						}
 					},
 
 					// func stringVal(value string) ref


### PR DESCRIPTION
This is a temporary fix for syscall/js.finalizeRef not implemented error until when https://github.com/tinygo-org/tinygo/issues/1140 is implemented.

<img width="1314" alt="Screenshot 2024-07-14 at 16 09 35" src="https://github.com/user-attachments/assets/525cdb5d-2cff-45e1-aefb-2f0eee624a78">

Currently using standard `Go` to compile for `wasm` in `production` until when this issue will be fixed in the `TinyGo` main [release](https://github.com/tinygo-org/tinygo/releases). 

Meanwhile `TinyGo` will only be used in `development` when compiling for our `wasm` use cases.